### PR TITLE
Drive/fix encoders

### DIFF
--- a/src/main/java/frc/robot/constants/CurrentConstants.java
+++ b/src/main/java/frc/robot/constants/CurrentConstants.java
@@ -21,8 +21,7 @@ public final class CurrentConstants
         public static final int REAR_RIGHT_MOTOR_ID = 23;
 
         /* Encoder */
-        public static final double DISTANCE_PER_PULSE = (2.0 * Math.PI * 3.0)
-                / 10.71;
+        public static final double DISTANCE_PER_PULSE = (6.0 * Math.PI) / 8.45;
         public static final double DRIVE_STRAIGHT_CORRECTION_DELTA = 0.1;
 
         /* MOTOR CONTROLLER GROUPS */
@@ -78,7 +77,7 @@ public final class CurrentConstants
     public static final class CameraConstants
         {
         /* SOFTWARE PROPERTIES */
-        public static final boolean CAMERA_ENABLED = false;
+        public static final boolean CAMERA_ENABLED = true;
         public static final boolean USING_TWO_CAMERAS = false;
 
         /* BUTTON IDS */
@@ -89,7 +88,7 @@ public final class CurrentConstants
             { 340, 240 };
         public static final int FRAMES_PER_SECOND = 20;
         public static final int COMPRESSION = 60;
-        public static final int BRIGHTNESS = 100;
+        public static final int BRIGHTNESS = 35;
         }
 
     public static final class FlipperPistonConstants

--- a/src/main/java/frc/robot/subsystems/TankSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TankSubsystem.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import com.playingwithfusion.CANVenom;
+import com.playingwithfusion.CANVenom.BrakeCoastMode;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -83,6 +84,10 @@ public class TankSubsystem extends SubsystemBase
 			leftEncoder.reset();
 			rightEncoder.reset();
 
+			/* Set Braking */
+			frontLeftMotor.setBrakeCoastMode(BrakeCoastMode.Brake);
+			frontRightMotor.setBrakeCoastMode(BrakeCoastMode.Brake);
+
 			/* Initialize Gyro */
 			gyro.calibrate();
 
@@ -162,6 +167,8 @@ public class TankSubsystem extends SubsystemBase
 
 		pose = odometry.update(new Rotation2d(Math.toRadians(gyroAngle)),
 				leftEncoder.getDistance(), rightEncoder.getDistance());
+
+		System.out.println("Encoders?? " + leftEncoder.getDistance());
 	}
 
 	/**


### PR DESCRIPTION
# Purpose
Fixes the encoder distance measuring, also sets the `CANVenom` motors to braking mode instead of coasting mode 