### PR TITLE
temporarily disable april tags

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -12,12 +12,10 @@ import frc.robot.enums.Season;
  * Anything declared here should be prefaced with {@code public static}
  * </p>
  */
-public final class Constants
-  {
+public final class Constants {
   public static Season season = Season.CurrentSeason;
 
-  public static final class DriveConstants
-    {
+  public static final class DriveConstants {
     /* MOTOR IDs */
     public static int FRONT_LEFT_MOTOR_ID;
     public static int REAR_LEFT_MOTOR_ID;
@@ -46,12 +44,12 @@ public final class Constants
     /* Turning */
     public static double TURN_DEGREES_FUDGE_FACTOR;
     public static double TURN_RADIUS;
-    }
+  }
 
-  public static final class CameraConstants
-    {
+  public static final class CameraConstants {
     /* SOFTWARE PROPERTIES */
     public static boolean CAMERA_ENABLED;
+    public static boolean APRIL_TAGS_ENABLED;
     public static boolean USING_TWO_CAMERAS;
 
     /* BUTTON IDS */
@@ -62,10 +60,9 @@ public final class Constants
     public static int FRAMES_PER_SECOND;
     public static int COMPRESSION;
     public static int BRIGHTNESS;
-    }
+  }
 
-  public static final class AutonomousConstants
-    {
+  public static final class AutonomousConstants {
     /* Autonomous Hardware IDs */
 
     /* Autonomous Delay */
@@ -73,19 +70,17 @@ public final class Constants
     /* Autonomous Drive Constants */
 
     /* Autonomous Mode */
-    }
+  }
 
-  public static final class JoystickConstants
-    {
+  public static final class JoystickConstants {
     /* JOYSTICK IDs */
     public static int LEFT_DRIVER_JOYSTICK_ID;
     public static int RIGHT_DRIVER_JOYSTICK_ID;
     public static int LEFT_OPERATOR_JOYSTICK_ID;
     public static int RIGHT_OPERATOR_JOYSTICK_ID;
-    }
+  }
 
-  public static final class FlipperPistonConstants
-    {
+  public static final class FlipperPistonConstants {
     /* DOUBLE SOLENOID PORTS */
     public static int LEFT_PISTON_FWD_PORT;
     public static int LEFT_PISTON_REV_PORT;
@@ -95,16 +90,13 @@ public final class Constants
     /* BUTTON IDS */
     public static int FLIP_UP_BUTTON_ID;
     public static int FLIP_DOWN_BUTTON_ID;
-    }
+  }
 
-  public static final class DashboardConstants
-    {
-    }
+  public static final class DashboardConstants {
+  }
 
-  public static void initialize()
-  {
-    if (season == Season.CurrentSeason)
-      {
+  public static void initialize() {
+    if (season == Season.CurrentSeason) {
       DriveConstants.FRONT_LEFT_MOTOR_ID = CurrentConstants.DriveConstants.FRONT_LEFT_MOTOR_ID;
       DriveConstants.FRONT_RIGHT_MOTOR_ID = CurrentConstants.DriveConstants.FRONT_RIGHT_MOTOR_ID;
       DriveConstants.REAR_LEFT_MOTOR_ID = CurrentConstants.DriveConstants.REAR_LEFT_MOTOR_ID;
@@ -127,6 +119,7 @@ public final class Constants
       JoystickConstants.RIGHT_OPERATOR_JOYSTICK_ID = CurrentConstants.JoystickConstants.RIGHT_OPERATOR_JOYSTICK_ID;
 
       CameraConstants.CAMERA_ENABLED = CurrentConstants.CameraConstants.CAMERA_ENABLED;
+      CameraConstants.APRIL_TAGS_ENABLED = CurrentConstants.CameraConstants.APRIL_TAGS_ENABLED;
       CameraConstants.SWITCH_CAMERA_BUTTON_ID = CurrentConstants.CameraConstants.SWITCH_CAMERA_BUTTON_ID;
       CameraConstants.USING_TWO_CAMERAS = CurrentConstants.CameraConstants.USING_TWO_CAMERAS;
       CameraConstants.RESOLUTION = CurrentConstants.CameraConstants.RESOLUTION;
@@ -140,9 +133,7 @@ public final class Constants
       FlipperPistonConstants.RIGHT_PISTON_REV_PORT = CurrentConstants.FlipperPistonConstants.RIGHT_PISTON_REV_PORT;
       FlipperPistonConstants.FLIP_UP_BUTTON_ID = CurrentConstants.FlipperPistonConstants.FLIP_UP_BUTTON_ID;
       FlipperPistonConstants.FLIP_DOWN_BUTTON_ID = CurrentConstants.FlipperPistonConstants.FLIP_DOWN_BUTTON_ID;
-      }
-    else
-      {
+    } else {
       DriveConstants.FRONT_LEFT_MOTOR_ID = PreviousConstants.DriveConstants.FRONT_LEFT_MOTOR_ID;
       DriveConstants.FRONT_RIGHT_MOTOR_ID = PreviousConstants.DriveConstants.FRONT_RIGHT_MOTOR_ID;
       DriveConstants.REAR_LEFT_MOTOR_ID = PreviousConstants.DriveConstants.REAR_LEFT_MOTOR_ID;
@@ -165,6 +156,7 @@ public final class Constants
       JoystickConstants.RIGHT_OPERATOR_JOYSTICK_ID = PreviousConstants.JoystickConstants.RIGHT_OPERATOR_JOYSTICK_ID;
 
       CameraConstants.CAMERA_ENABLED = PreviousConstants.CameraConstants.CAMERA_ENABLED;
+      CameraConstants.APRIL_TAGS_ENABLED = PreviousConstants.CameraConstants.APRIL_TAGS_ENABLED;
       CameraConstants.SWITCH_CAMERA_BUTTON_ID = PreviousConstants.CameraConstants.SWITCH_CAMERA_BUTTON_ID;
       CameraConstants.USING_TWO_CAMERAS = PreviousConstants.CameraConstants.USING_TWO_CAMERAS;
       CameraConstants.RESOLUTION = PreviousConstants.CameraConstants.RESOLUTION;
@@ -178,6 +170,6 @@ public final class Constants
       FlipperPistonConstants.RIGHT_PISTON_REV_PORT = PreviousConstants.FlipperPistonConstants.RIGHT_PISTON_REV_PORT;
       FlipperPistonConstants.FLIP_UP_BUTTON_ID = PreviousConstants.FlipperPistonConstants.FLIP_UP_BUTTON_ID;
       FlipperPistonConstants.FLIP_DOWN_BUTTON_ID = PreviousConstants.FlipperPistonConstants.FLIP_DOWN_BUTTON_ID;
-      }
+    }
   }
-  }
+}

--- a/src/main/java/frc/robot/constants/CurrentConstants.java
+++ b/src/main/java/frc/robot/constants/CurrentConstants.java
@@ -10,10 +10,8 @@ import frc.robot.enums.DriveGears;
  * Anything declared here should be prefaced with {@code public static final}
  * </p>
  */
-public final class CurrentConstants
-    {
-    public static final class DriveConstants
-        {
+public final class CurrentConstants {
+    public static final class DriveConstants {
         /* MOTOR IDs */
         public static final int FRONT_LEFT_MOTOR_ID = 20;
         public static final int REAR_LEFT_MOTOR_ID = 21;
@@ -26,8 +24,7 @@ public final class CurrentConstants
         public static final double DRIVE_STRAIGHT_CORRECTION_DELTA = 0.1;
 
         /* MOTOR CONTROLLER GROUPS */
-        public static final boolean[] MOTOR_CONTROLLER_GROUPS_INVERTED =
-            { false, true };
+        public static final boolean[] MOTOR_CONTROLLER_GROUPS_INVERTED = { false, true };
 
         /* JOYSTICK DEADBAND */
         public static final double JOYSTICK_DEADBAND = 0.05;
@@ -44,14 +41,12 @@ public final class CurrentConstants
         /* Turning */
         public static final double TURN_DEGREES_FUDGE_FACTOR = 33.0;
         public static final double TURN_RADIUS = 16.75;
-        }
+    }
 
-    public static final class AutonomousConstants
-        {
+    public static final class AutonomousConstants {
         /* Autonomous Hardware IDs */
         public static final int USE_AUTO_SWITCH_ID = 10;
-        public static final int[] AUTO_SIX_POSITION_SWITCH_IDS =
-            { 15, 13, 14, 18, 16, 17 };
+        public static final int[] AUTO_SIX_POSITION_SWITCH_IDS = { 15, 13, 14, 18, 16, 17 };
         public static final int AUTO_DELAY_POT_ID = 2;
 
         /* Autonomous Delay */
@@ -64,19 +59,17 @@ public final class CurrentConstants
         /* Autonomous Mode */
         public static final int DEFAULT_AUTONOMOUS_MODE = 0;
         public static final boolean CHECK_MODE_FROM_DASHBOARD = true;
-        }
+    }
 
-    public static final class JoystickConstants
-        {
+    public static final class JoystickConstants {
         /* JOYSTICK IDs */
         public static final int LEFT_DRIVER_JOYSTICK_ID = 0;
         public static final int RIGHT_DRIVER_JOYSTICK_ID = 1;
         public static final int LEFT_OPERATOR_JOYSTICK_ID = 2;
         public static final int RIGHT_OPERATOR_JOYSTICK_ID = 3;
-        }
+    }
 
-    public static final class CameraConstants
-        {
+    public static final class CameraConstants {
         /* SOFTWARE PROPERTIES */
         public static final boolean CAMERA_ENABLED = true;
         public static final boolean APRIL_TAGS_ENABLED = false;
@@ -86,15 +79,13 @@ public final class CurrentConstants
         public static final int SWITCH_CAMERA_BUTTON_ID = 10;
 
         /* CAMERA PROPERTIES */
-        public static final int[] RESOLUTION =
-            { 340, 240 };
+        public static final int[] RESOLUTION = { 340, 240 };
         public static final int FRAMES_PER_SECOND = 20;
         public static final int COMPRESSION = 60;
-        public static final int BRIGHTNESS = 100;
-        }
+        public static final int BRIGHTNESS = 35;
+    }
 
-    public static final class FlipperPistonConstants
-        {
+    public static final class FlipperPistonConstants {
         /* DOUBLE SOLENOID PORTS */
         public static final int LEFT_PISTON_FWD_PORT = 2;
         public static final int LEFT_PISTON_REV_PORT = 3;
@@ -104,11 +95,10 @@ public final class CurrentConstants
         /* BUTTON IDS */
         public static final int FLIP_UP_BUTTON_ID = 1;
         public static final int FLIP_DOWN_BUTTON_ID = 1;
-        }
+    }
 
-    public static final class DashboardConstants
-        {
+    public static final class DashboardConstants {
         /* Battery Level */
         public static final double LOW_BATTERY_LEVEL = 11.5;
-        }
     }
+}

--- a/src/main/java/frc/robot/constants/CurrentConstants.java
+++ b/src/main/java/frc/robot/constants/CurrentConstants.java
@@ -78,7 +78,8 @@ public final class CurrentConstants
     public static final class CameraConstants
         {
         /* SOFTWARE PROPERTIES */
-        public static final boolean CAMERA_ENABLED = false;
+        public static final boolean CAMERA_ENABLED = true;
+        public static final boolean APRIL_TAGS_ENABLED = false;
         public static final boolean USING_TWO_CAMERAS = false;
 
         /* BUTTON IDS */

--- a/src/main/java/frc/robot/constants/PreviousConstants.java
+++ b/src/main/java/frc/robot/constants/PreviousConstants.java
@@ -78,6 +78,7 @@ public final class PreviousConstants
         {
         /* SOFTWARE PROPERTIES */
         public static final boolean CAMERA_ENABLED = true;
+        public static final boolean APRIL_TAGS_ENABLED = false;
         public static final boolean USING_TWO_CAMERAS = false;
 
         /* BUTTON IDS */

--- a/src/main/java/frc/robot/modules/AprilTagModule.java
+++ b/src/main/java/frc/robot/modules/AprilTagModule.java
@@ -19,8 +19,7 @@ import frc.robot.Constants.CameraConstants;
 import frc.robot.enums.AprilTagLocations;
 import frc.robot.subsystems.CameraSubsystem;
 
-public class AprilTagModule
-    {
+public class AprilTagModule {
     private static AprilTagLocations currentLocation = null;
 
     /**
@@ -30,12 +29,9 @@ public class AprilTagModule
      * @param cameraSubsystem
      * @return
      */
-    public static Runnable getDetectorRunnable(CameraSubsystem cameraSubsystem)
-    {
-        return () ->
-            {
-            if (CameraConstants.CAMERA_ENABLED)
-                {
+    public static Runnable getDetectorRunnable(CameraSubsystem cameraSubsystem) {
+        return () -> {
+            if (CameraConstants.CAMERA_ENABLED && CameraConstants.APRIL_TAGS_ENABLED) {
                 CvSink cvSink = CameraServer.getVideo();
                 CvSource outputStream = CameraServer.putVideo("AprilTagDebug",
                         CameraConstants.RESOLUTION[0],
@@ -70,13 +66,11 @@ public class AprilTagModule
                 Timer timer = new Timer();
                 timer.start();
 
-                while (!Thread.interrupted())
-                    {
-                    if (cvSink.grabFrame(mat) == 0)
-                        {
+                while (!Thread.interrupted()) {
+                    if (cvSink.grabFrame(mat) == 0) {
                         outputStream.notifyError(cvSink.getError());
                         continue;
-                        }
+                    }
 
                     Imgproc.cvtColor(mat, grayMat, Imgproc.COLOR_RGB2GRAY);
 
@@ -85,8 +79,7 @@ public class AprilTagModule
 
                     HashSet<Integer> set = new HashSet<Integer>();
 
-                    for (var result : results)
-                        {
+                    for (var result : results) {
                         pt0.x = result.getCornerX(0);
                         pt1.x = result.getCornerX(1);
                         pt2.x = result.getCornerX(2);
@@ -111,29 +104,26 @@ public class AprilTagModule
                         Imgproc.putText(mat, String.valueOf(result.getId()),
                                 pt2, Imgproc.FONT_HERSHEY_SIMPLEX, 2, green, 7);
 
-                        }
+                    }
                     ;
 
-                    for (int id : set)
-                        {
+                    for (int id : set) {
                         setCurrentLocation(AprilTagLocations.getFromId(id));
-                        }
+                    }
 
                     outputStream.putFrame(mat);
-                    }
-                aprilTagDetector.close();
                 }
-            };
+                aprilTagDetector.close();
+            }
+        };
     }
 
-    public static AprilTagLocations getCurrentLocation()
-    {
+    public static AprilTagLocations getCurrentLocation() {
         return currentLocation;
     }
 
-    public static void setCurrentLocation(final AprilTagLocations newLocation)
-    {
+    public static void setCurrentLocation(final AprilTagLocations newLocation) {
         currentLocation = newLocation;
         System.out.println("Current Location: " + currentLocation.getId());
     }
-    }
+}


### PR DESCRIPTION
# Purpose
This PR adds a constant to enable/disable april tags, so you can use camera w/out april tag functionality. Currently with `v2024.3.1`, AprilTag libraries are not functioning properly.

There will be another PR (to be linked) for when april tags are fixed

This branch will stay open after this PR closes.