### PR TITLE
fix(robot): disable the piston movement in teleop init

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -110,7 +110,7 @@ public class Robot extends TimedRobot
   @Override
   public void autonomousInit()
   {
-/* Initial States */
+    /* Initial States */
     robotContainer.flipperPistonSubsystem.flipDown();
     autonomousCommand = robotContainer.getAutonomousCommand();
 
@@ -146,9 +146,6 @@ public class Robot extends TimedRobot
       autonomousCommand.endAutonomous();
       autonomousCommand = null;
       }
-
-    /* Initial States */
-    robotContainer.flipperPistonSubsystem.flipDown();
 
     // ==============================
     // All user code goes above here


### PR DESCRIPTION
_wow that's a long branch name_
# Purpose
This PR prevents the extra piston movements, as we don't want the piston to drop back down from autonomous to teleop since we need to get the next note.