### PR TITLE
fix(Autonomous): increase distances to/from start line and to amp

### DIFF
--- a/src/main/java/frc/robot/commands/autonomous/ScoreAmp.java
+++ b/src/main/java/frc/robot/commands/autonomous/ScoreAmp.java
@@ -54,7 +54,7 @@ public class ScoreAmp extends AutonomousCommandBase
     /*
      * Drive Forward 2 Distance
      */
-    public static int driveForwardDistance2 = 27;
+    public static int driveForwardDistance2 = 36;
 
     /**
      * Constructor

--- a/src/main/java/frc/robot/commands/autonomous/ScoreAmp.java
+++ b/src/main/java/frc/robot/commands/autonomous/ScoreAmp.java
@@ -25,12 +25,12 @@ public class ScoreAmp extends AutonomousCommandBase
     /*
      * Drive Forward 1 Distance
      */
-    public static int driveForwardDistance1 = 45;
+    public static int driveForwardDistance1 = 54;
 
     /**
      * Drive Rerverse Distance
      */
-    public static int driveReverseDistance = -15;
+    public static int driveReverseDistance = -24;
 
     /**
      * The delay between stopping and flipping the pizza box up


### PR DESCRIPTION
# Purpose
Apparently, the distances to/from the start line, and to the amp are a tad bit too short, so this PR increases them to ensure the robot makes it where it needs to go.